### PR TITLE
Fix reciprocal germany-czech_republic border

### DIFF
--- a/src/four_color_theorem/index.pl
+++ b/src/four_color_theorem/index.pl
@@ -15,7 +15,7 @@ neighbours(finland        , [estonia, sweden]).
 neighbours(france         , [spain, belgium, luxemburg, germany, italy,
                              united_kingdom]).
 neighbours(germany        , [netherlands, belgium, luxemburg, denmark,
-                             france, austria, poland]).
+                             france, austria, poland, czech_republic]).
 neighbours(greece         , [bulgaria, cyprus]).
 neighbours(hungary        , [austria, slovakia, romania, croatia,
                              slovenia]).
@@ -24,7 +24,7 @@ neighbours(italy          , [france, austria, slovenia]).
 neighbours(latvia         , [estonia, lithuania]).
 neighbours(luxemburg      , [belgium, france, germany]).
 neighbours(malta          , []).
-neighbours(netherlands    , [belgium, germany , united_kingdom]).
+neighbours(netherlands    , [belgium, germany, united_kingdom]).
 neighbours(poland         , [germany, czech_republic, slovakia,
                              lithuania]).
 neighbours(portugal       , [spain]).


### PR DESCRIPTION
`neighbour/2` should be symmetric.

I wonder if this error could have been avoided, and the list of border facts cut in half, by also defining the rule

```
neighbour(CountryA, CountryB):-
  neighbour(CountryB, CountryA).
```

In any case, thanks for writing up this exercise. Very interesting. I'm still working my way through it!